### PR TITLE
chore: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up ${{ matrix.go-version }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Generate TLS test certificates
       if: matrix.platform == 'ubuntu-latest'


### PR DESCRIPTION
GitHub is deprecating the **node20** runner for GitHub Actions on **June 16, 2026**. Workflow steps using node20-based action versions will fail after this date.

This PR bumps all affected actions to their latest node24-compatible versions.

> Reviewed by 3 independent agents (opus/sonnet/haiku) before opening.