### PR TITLE
ci: fix ubuntu-20.04 deprecation, update Go matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,17 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build-ubuntu:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, ubuntu-20.04]
-        go-version: [1.20.x, 1.21.x]
+        platform: [ubuntu-latest, ubuntu-22.04]
+        go-version: [1.22.x, 1.23.x]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up ${{ matrix.go-version }}
@@ -27,7 +30,7 @@ jobs:
     - name: Install Redis
       run: |
         curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+        echo "deb [signed-by=/usr.share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
         sudo apt-get -qq update
         sudo apt-get install redis
         sudo service redis-server stop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Redis
       run: |
         curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-        echo "deb [signed-by=/usr.share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+        echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
         sudo apt-get -qq update
         sudo apt-get install redis
         sudo service redis-server stop
@@ -46,7 +46,7 @@ jobs:
 
     - name: build tool
       run: |
-        go build .  
+        go build .
 
     - name: Test OSS TCP
       timeout-minutes: 10


### PR DESCRIPTION
## Changes

- Replace deprecated `ubuntu-20.04` runner with `ubuntu-22.04` — GitHub retired ubuntu-20.04 runners, causing all CI jobs targeting that platform to queue indefinitely and never start
- Bump Go test matrix from `[1.20.x, 1.21.x]` → `[1.22.x, 1.23.x]` to match current supported releases
- Add `workflow_dispatch` trigger for manual re-runs

## Root cause

All recent CI runs were stuck in `queued` or `cancelled` state because `ubuntu-20.04` runners are no longer available on GitHub-hosted runners.